### PR TITLE
fix/process management

### DIFF
--- a/scripts/tmux-dark-notify-runner.sh
+++ b/scripts/tmux-dark-notify-runner.sh
@@ -1,23 +1,51 @@
 #!/usr/bin/env bash
 # This script will run dark-notify(1) in a while loop (in case it would exit).
+# Each tmux server gets its own runner, tracked via a PID file keyed by the
+# tmux socket path.
 
 set -o errexit
 set -o pipefail
 [[ "${TRACE-0}" =~ ^1|t|y|true|yes$ ]] && set -o xtrace
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-SCRIPT_NAME="$(basename $0)"
+SCRIPT_NAME="$(basename "$0")"
 TMUX_THEME_SETTER="${CURRENT_DIR}/tmux-theme-mode.sh"
 
 program_is_in_path() {
 	local program="$1"
-	type "$1" >/dev/null 2>&1
+	type "$program" >/dev/null 2>&1
 }
 
-if pgrep -f "$SCRIPT_NAME" | grep -qv "^$$\$"; then
-	echo "$SCRIPT_NAME is already running, nothing to do here."
-	exit 0
+# Per-server PID file based on the tmux socket path
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/tmux"
+mkdir -p "$STATE_DIR"
+TMUX_SOCKET="${TMUX%%,*}"
+PID_FILE_KEY="$(md5 -qs "$TMUX_SOCKET")"
+PID_FILE="${STATE_DIR}/tmux-dark-notify-${PID_FILE_KEY}.pid"
+
+DARK_NOTIFY_PID=
+
+cleanup() {
+	rm -f "$PID_FILE"
+	if [[ -n "$DARK_NOTIFY_PID" ]]; then
+		kill "$DARK_NOTIFY_PID" 2>/dev/null || true
+	fi
+}
+
+trap cleanup EXIT TERM HUP INT
+
+# Check if another runner for this tmux server is already active
+if [[ -f "$PID_FILE" ]]; then
+	existing_pid="$(cat "$PID_FILE")"
+	if kill -0 "$existing_pid" 2>/dev/null; then
+		echo "$SCRIPT_NAME is already running for this tmux server (PID $existing_pid)."
+		exit 0
+	fi
+	# Stale PID file, remove it
+	rm -f "$PID_FILE"
 fi
+
+echo $$ > "$PID_FILE"
 
 # Load Homebrew PATHs
 if ! program_is_in_path brew; then
@@ -32,5 +60,9 @@ if ! program_is_in_path dark-notify; then
 fi
 
 while :; do
-	dark-notify -c "$TMUX_THEME_SETTER"
+	dark-notify -c "$TMUX_THEME_SETTER" &
+	DARK_NOTIFY_PID=$!
+	wait "$DARK_NOTIFY_PID" || true
+	DARK_NOTIFY_PID=
+	sleep 1
 done

--- a/scripts/tmux-dark-notify-runner.sh
+++ b/scripts/tmux-dark-notify-runner.sh
@@ -14,7 +14,7 @@ program_is_in_path() {
 	type "$1" >/dev/null 2>&1
 }
 
-if pgrep -qf "$SCRIPT_NAME"; then
+if pgrep -f "$SCRIPT_NAME" | grep -qv "^$$\$"; then
 	echo "$SCRIPT_NAME is already running, nothing to do here."
 	exit 0
 fi

--- a/scripts/tmux-theme-mode.sh
+++ b/scripts/tmux-theme-mode.sh
@@ -67,7 +67,7 @@ mode="$1"
 if [[ -z "$mode" ]]; then
 	echo "Missing required argument 'mode'." >&2
 	exit 1
-elif [[ "$mode" != light ]] && [[ "$1" != dark ]]; then
+elif [[ "$mode" != light ]] && [[ "$mode" != dark ]]; then
 	echo "Mode must be 'light' or 'dark'." >&2
 	exit 2
 fi


### PR DESCRIPTION
Thanks for the plugin! This PR fixes a couple of bugs and cleans up one potential bug.

The first is that the `pgrep` check could / would probably return true due to finding its own process, so I added an exclusion of its own PID. Copilot gave some feedback about a possible race condition, which seems unlikely given how this plugin is used, and the suggested fix seems overly complicated for the use case. But if you like that adjustment, or would like me to investigate more, I'm happy to do so.

The second (and the real reason I'm here) is that the script as it was assumed that there would only be at most one copy of the runner running at any given time. But I'm in the habit of running a few tmux servers, on different ports. So I added some guard code to handle the multiple port case. This is a little hefty for my taste, again especially given the context / way it's used etc. And again Copilot's feedback is valid, but would make the code even heftier. If you'd like me to investigate more, happy to do so.

The last fix is just making the variable reference in the mode check consistent. I assume that's just cruft or a typo.

Let me know how this looks! Thanks.